### PR TITLE
DOM-14267: Legacy pinning of ranchhand module version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -313,7 +313,7 @@ resource "aws_security_group_rule" "provisioner_secgrp_ingress_443" {
 # Provisioner
 #------------------------------------------------------------------------------
 module "ranchhand" {
-  source = "github.com/dominodatalab/ranchhand/terraform"
+  source = "github.com/dominodatalab/ranchhand.git//terraform?ref=${var.ranchhand_release}"
 
   node_ips = ["${split(",", replace(join(",", formatlist("%s:%s", aws_instance.this.*.public_ip, aws_instance.this.*.private_ip)), "/^:|(,):/", "$1"))}"]
 

--- a/main.tf
+++ b/main.tf
@@ -313,7 +313,7 @@ resource "aws_security_group_rule" "provisioner_secgrp_ingress_443" {
 # Provisioner
 #------------------------------------------------------------------------------
 module "ranchhand" {
-  source = "github.com/dominodatalab/ranchhand.git//terraform?ref=${var.ranchhand_release}"
+  source = "github.com/dominodatalab/ranchhand.git//terraform?ref=v0.1.0-rc19"
 
   node_ips = ["${split(",", replace(join(",", formatlist("%s:%s", aws_instance.this.*.public_ip, aws_instance.this.*.private_ip)), "/^:|(,):/", "$1"))}"]
 

--- a/variables.tf
+++ b/variables.tf
@@ -125,7 +125,7 @@ variable "ranchhand_distro" {
 
 variable "ranchhand_release" {
   description = "Specify the RanchHand release version to use. Check https://github.com/dominodatalab/ranchhand/releases for a list of available releases."
-  default     = "latest"
+  default     = "v0.1.0-rc19"
 }
 
 variable "ranchhand_working_dir" {


### PR DESCRIPTION
We've been using the latest ranchhand terraform module within this one, which means that we need to maintain compatibility with 0.11 in our master branch.

This pins to the terraform of the most recent ranchhand release as of today, with the intent to update the v1.0.0 terraform-aws-ranchhand tag to the commit where this is merged. All previous deployers are pinned to v1.0.0 of this, so this means that 0.11 deployers all will continue to work with this code base, and a 0.12 code base can be present in future commits.