### PR TITLE
add an SSH connectivity check to instances

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,17 @@ resource "aws_instance" "this" {
       "Terraform" = "true"
     },
   )
+
+  provisioner "remote-exec" {
+    inline = "echo 'sshd is running'"
+
+    connection {
+      user         = "${var.ssh_username}"
+      private_key  = "${file(var.ssh_key_path)}"
+      bastion_host = "${var.ssh_proxy_host}"
+      bastion_user = "${var.ssh_proxy_user}"
+    }
+  }
 }
 
 #------------------------------------------------------------------------------
@@ -365,4 +376,3 @@ module "ranchhand" {
 
   admin_password = var.admin_password
 }
-


### PR DESCRIPTION
We had this in the [tf-azure-rancher module](https://github.com/cerebrotech/terraform-azure-rancher/blob/3b370efcfcef71af45c0d1a3683212cd76460341/main.tf#L123-L131), but not here. Might help with some of the intermittent connectivity issues on provision?