### PR TITLE
DOM-17465: On v12 installs, use ranchhand w/rhel fixes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -313,7 +313,7 @@ resource "aws_security_group_rule" "provisioner_secgrp_ingress_443" {
 # Provisioner
 #------------------------------------------------------------------------------
 module "ranchhand" {
-  source = "github.com/dominodatalab/ranchhand.git//terraform?ref=DOM-17465"
+  source = "github.com/dominodatalab/ranchhand.git//terraform?ref=v0.1.0-rc20"
 
   node_ips = ["${split(",", replace(join(",", formatlist("%s:%s", aws_instance.this.*.public_ip, aws_instance.this.*.private_ip)), "/^:|(,):/", "$1"))}"]
 

--- a/main.tf
+++ b/main.tf
@@ -313,7 +313,7 @@ resource "aws_security_group_rule" "provisioner_secgrp_ingress_443" {
 # Provisioner
 #------------------------------------------------------------------------------
 module "ranchhand" {
-  source = "github.com/dominodatalab/ranchhand.git//terraform?ref=v0.1.0-rc19"
+  source = "github.com/dominodatalab/ranchhand.git//terraform?ref=DOM-17465"
 
   node_ips = ["${split(",", replace(join(",", formatlist("%s:%s", aws_instance.this.*.public_ip, aws_instance.this.*.private_ip)), "/^:|(,):/", "$1"))}"]
 

--- a/variables.tf
+++ b/variables.tf
@@ -125,7 +125,7 @@ variable "ranchhand_distro" {
 
 variable "ranchhand_release" {
   description = "Specify the RanchHand release version to use. Check https://github.com/dominodatalab/ranchhand/releases for a list of available releases."
-  default     = "v0.1.0-rc19"
+  default     = "DOM-17465"
 }
 
 variable "ranchhand_working_dir" {

--- a/variables.tf
+++ b/variables.tf
@@ -125,7 +125,7 @@ variable "ranchhand_distro" {
 
 variable "ranchhand_release" {
   description = "Specify the RanchHand release version to use. Check https://github.com/dominodatalab/ranchhand/releases for a list of available releases."
-  default     = "DOM-17465"
+  default     = "v0.1.0-rc20"
 }
 
 variable "ranchhand_working_dir" {


### PR DESCRIPTION
Classic RanchHand is being updated with a compatibility fix for RHEL. Update to that.

(at present points to the working branch, but will be updated to a tag)